### PR TITLE
Optimize ModCreativeModTabs.java

### DIFF
--- a/src/main/java/dev/dhyces/lunarnether/registry/ModCreativeModTabs.java
+++ b/src/main/java/dev/dhyces/lunarnether/registry/ModCreativeModTabs.java
@@ -17,41 +17,7 @@ public class ModCreativeModTabs {
 
         public static final RegistryObject<CreativeModeTab> MOON_TAB = CREATIVE_MODE_TABS.register("moon_tab", () -> CreativeModeTab.builder().icon(()-> new ItemStack(ModItems.LUNAR_STONE.get()))
         .title(Component.translatable("creativetab.lunarnether.main"))
-        .displayItems((pParameters, pOutput) -> {
-            //all the obtainable items need to be here. Weirdly couldn't find an easy way to do this automatically for every item in the mod.
-            pOutput.accept(ModItems.LUNAR_DUST.get());
-            pOutput.accept(ModItems.LUNAR_STONE.get());
-            pOutput.accept(ModItems.LUNAR_STONE_STAIRS.get());
-            pOutput.accept(ModItems.LUNAR_STONE_SLAB.get());
-            pOutput.accept(ModItems.LUNAR_STONE_WALL.get());
-
-            pOutput.accept(ModItems.POLISHED_LUNAR_STONE.get());
-            pOutput.accept(ModItems.POLISHED_LUNAR_STONE_STAIRS.get());
-            pOutput.accept(ModItems.POLISHED_LUNAR_STONE_SLAB.get());
-            pOutput.accept(ModItems.POLISHED_LUNAR_STONE_WALL.get());
-
-            pOutput.accept(ModItems.CUT_POLISHED_LUNAR_STONE.get());
-            pOutput.accept(ModItems.CUT_POLISHED_LUNAR_STONE_STAIRS.get());
-            pOutput.accept(ModItems.CUT_POLISHED_LUNAR_STONE_SLAB.get());
-            pOutput.accept(ModItems.CUT_POLISHED_LUNAR_STONE_WALL.get());
-            
-            pOutput.accept(ModItems.ASTRALITH.get());
-
-            pOutput.accept(ModItems.ILMENITE_ORE.get());
-            pOutput.accept(ModItems.RAW_ILMENITE_BLOCK.get());
-
-            pOutput.accept(ModItems.TITANIUM_BLOCK.get());
-
-            pOutput.accept(ModItems.CUT_TITANIUM.get());
-            pOutput.accept(ModItems.CUT_TITANIUM_STAIRS.get());
-            pOutput.accept(ModItems.CUT_TITANIUM_SLAB.get());
-
-            pOutput.accept(ModItems.RAW_ILMENITE.get());
-            pOutput.accept(ModItems.TITANIUM_INGOT.get());
-            pOutput.accept(ModItems.TITANIUM_NUGGET.get());
-
-            pOutput.accept(ModItems.LUNAR_CLOCK.get());
-            pOutput.accept(ModItems.MOLTEN_TITANIUM_BUCKET.get());
-        })
+        .displayItems((pParameters, pOutput) ->
+                ModItems.REGISTRY.getEntries().forEach((item) -> pOutput.accept(item.get())))
         .build());
 }


### PR DESCRIPTION
Since you're adding every item in the mod to this creative tab, instead of manually listing every item you can iterate through the ModItems registry and add every item inside it. If at some point this changes (i.e. there are items you want to exclude from the creative menu) you can do something like create a tag and compare against that tag from within the forEach.

This new version *does* come with a minor side effect that items follow the order they are registered, though currently the only effect that has is pushing Astralith toward the end of the list.